### PR TITLE
Adjust to https://github.com/homalg-project/CAP_project/pull/649

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,8 +19,8 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-      # keep workflow active even if repository has no activity for 60 days
-      - run: 'curl --fail -X PUT -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/Tests.yml/enable'
+      # keep workflow active even if repository has no activity for 60 days (do not execute for pull requests)
+      - run: '[ "$GITHUB_EVENT_NAME" = "pull_request" ] || curl --fail -X PUT -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/Tests.yml/enable'
       - uses: actions/checkout@v1
       - run: mkdir -p /home/gap/.gap/pkg/
       - run: sudo cp -a $GITHUB_WORKSPACE /home/gap/.gap/pkg/

--- a/BBGG/tst/050_LoadPackage.tst
+++ b/BBGG/tst/050_LoadPackage.tst
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# BBGG: Beilinson monads and derived categories for coherent sheaves over P^n
-#
-# This file tests if the package can be loaded without errors or warnings.
-#
-
-gap> LoadPackage( "FreydCategoriesForCAP", false );
-#I  method installed for IsInjective matches more than one declaration
-true

--- a/ComplexesCategories/PackageInfo.g
+++ b/ComplexesCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ComplexesCategories",
 Subtitle := "Category of (co)chain complexes of an additive category",
-Version := "2020.11-22",
+Version := "2021.03-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -75,8 +75,8 @@ Dependencies := rec(
   GAP := ">= 4.8",
   NeededOtherPackages := [
                             [ "AutoDoc", ">= 2019.09.04" ],
-                            [ "CAP", ">= 2020.10-01" ],
-                            [ "MonoidalCategories", ">= 2020.10-01" ],
+                            [ "CAP", ">= 2021.03-01" ],
+                            [ "MonoidalCategories", ">= 2021.03-01" ],
                             [ "ToolsForHigherHomologicalAlgebra", ">= 2020.10-02" ],
                          ],
   SuggestedOtherPackages := [

--- a/ComplexesCategories/gap/Categories.gi
+++ b/ComplexesCategories/gap/Categories.gi
@@ -22,13 +22,13 @@ InstallValue( NULL_HOMOTOPIC_METHOD_FOR_COMPLEXCES_CATEGORIES, rec(
 
   IsNullHomotopic := rec(
     installation_name := "IsNullHomotopic", 
-    filter_list := [ "morphism" ],
+    filter_list := [ "category", "morphism" ],
     cache_name := "IsNullHomotopic",
     return_type := "bool" ),
 
   HomotopyMorphisms := rec( 
     installation_name := "HomotopyMorphisms", 
-    filter_list := [ "morphism" ],
+    filter_list := [ "category", "morphism" ],
     cache_name := "HomotopyMorphisms",
     return_type := IsZFunction ),
 

--- a/ComplexesCategories/gap/Derivations.gi
+++ b/ComplexesCategories/gap/Derivations.gi
@@ -19,7 +19,7 @@ AddDerivationToCAP( IsNullHomotopic,
                 [
                     [ HomotopyMorphisms, 1 ],
                 ],
-    function( phi )
+    function( cat, phi )
     
       return HomotopyMorphisms( phi ) <> fail;
       
@@ -31,7 +31,7 @@ AddDerivationToCAP( HomotopyMorphisms,
                 [
                     #[ IdentityMorphism, 1 ] # this should be modified!
                 ],
-  function( phi )
+  function( cat, phi )
     local A, B, m, n, L, K, b, sol, H;
     
     A := Source( phi );
@@ -148,7 +148,7 @@ AddDerivationToCAP( HomotopyMorphisms,
                 [
                     #[ IdentityMorphism, 1 ]
                 ],
-  function( phi )
+  function( cat, phi )
     local A, B, m, n, L, K, b, sol, H;
     
     A := Source( phi );
@@ -269,7 +269,7 @@ AddFinalDerivation( HomotopyMorphisms,
                 [
                   HomotopyMorphisms
                 ],
-  function( phi )
+  function( cat, phi )
     local C, D, colift;
     
     C := Source( phi );
@@ -313,7 +313,7 @@ AddFinalDerivation( HomotopyMorphisms,
                 [
                   HomotopyMorphisms
                 ],
-  function( phi )
+  function( cat, phi )
     local C, D, colift;
     
     C := Source( phi );
@@ -359,10 +359,8 @@ AddDerivationToCAP( Lift,
               [ HomomorphismStructureOnMorphismsWithGivenObjects, 1 ],
               [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism, 1 ]
             ],
-  function( alpha, beta )
-    local cat, P, N, M, D, D_to_hom_PN, PM_to_PN, m1, m2, lift;
-    
-    cat := CapCategory( alpha );
+  function( cat, alpha, beta )
+    local P, N, M, D, D_to_hom_PN, PM_to_PN, m1, m2, lift;
     
     P := Source( alpha );
     
@@ -469,11 +467,9 @@ AddDerivationToCAP( Colift,
               [ HomomorphismStructureOnMorphismsWithGivenObjects, 1 ],
               [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism, 1 ]
             ],
-  function( alpha, beta )
-    local cat, M, N, I, D, D_to_hom_MI, NI_to_MI, m1, m2, lift;
+  function( cat, alpha, beta )
+    local M, N, I, D, D_to_hom_MI, NI_to_MI, m1, m2, lift;
   
-    cat := CapCategory( alpha );
-    
     M := Source( alpha );
     
     N := Range( alpha );
@@ -578,7 +574,7 @@ AddDerivationToCAP( Lift,
               [ HomomorphismStructureOnMorphismsWithGivenObjects, 1 ],
               [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism, 1 ]
             ],
-  function( alpha, beta )
+  function( cat, alpha, beta )
     local f, g, l;
     
     f := InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( alpha );
@@ -630,7 +626,7 @@ AddDerivationToCAP( Colift,
               [ HomomorphismStructureOnMorphismsWithGivenObjects, 1 ],
               [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism, 1 ]
             ],
-  function( alpha, beta )
+  function( cat, alpha, beta )
     local f, g, l;
     
     f := InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( beta );

--- a/ComplexesCategories/tst/050_LoadPackage.tst
+++ b/ComplexesCategories/tst/050_LoadPackage.tst
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# ComplexesCategories: Category of (co)chain complexes of an additive category
-#
-# This file tests if the package can be loaded without errors or warnings.
-#
-
-gap> LoadPackage( "FreydCategoriesForCAP", false );
-#I  method installed for IsInjective matches more than one declaration
-true

--- a/DerivedCategories/tst/050_LoadPackage.tst
+++ b/DerivedCategories/tst/050_LoadPackage.tst
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# DerivedCategories: Derived categories of Abelian categories
-#
-# This file tests if the package can be loaded without errors or warnings.
-#
-
-gap> LoadPackage( "FreydCategoriesForCAP", false );
-#I  method installed for IsInjective matches more than one declaration
-true

--- a/HomotopyCategories/PackageInfo.g
+++ b/HomotopyCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "HomotopyCategories",
 Subtitle := "Homotopy categories of additive categories",
-Version := "2020.12-01",
+Version := "2021.03-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -73,10 +73,10 @@ Dependencies := rec(
   NeededOtherPackages := [
                            [ "GAPDoc", ">= 1.5" ],
                            [ "ToolsForHigherHomologicalAlgebra", ">= 2020.10-02" ],
-                           [ "ComplexesCategories", ">= 2020.11-20" ],
+                           [ "ComplexesCategories", ">= 2021.03-01" ],
                            [ "GeneralizedMorphismsForCAP", ">= 2020.10.01" ],
-                           [ "StableCategories", ">= 2020.10-01" ],
-                           [ "TriangulatedCategories", ">= 2020.10-04" ],
+                           [ "StableCategories", ">= 2021.03-01" ],
+                           [ "TriangulatedCategories", ">= 2021.03-01" ],
                            [ "Algebroids", ">= 2020.10-02" ],
                          ],
   SuggestedOtherPackages := [ ],

--- a/HomotopyCategories/gap/DerivedMethods.gi
+++ b/HomotopyCategories/gap/DerivedMethods.gi
@@ -7,7 +7,7 @@
 AddFinalDerivation( MorphismIntoColiftingObject,
                     [ ],
                     [ MorphismIntoColiftingObject ],
-  function( a )
+  function( cat, a )
     
     return NaturalInjectionInMappingCone( IdentityMorphism( a ) );
   
@@ -25,7 +25,7 @@ AddFinalDerivation( IsColiftableThroughColiftingObject,
                       IsColiftableThroughColiftingObject,
                       MorphismIntoColiftingObject  
                     ],
-  function( alpha )
+  function( cat, alpha )
     local a, I_a;
      
     a := Source( alpha );
@@ -48,7 +48,7 @@ AddFinalDerivation( IsColiftableThroughColiftingObject,
                       IsColiftableThroughColiftingObject,
                       MorphismIntoColiftingObject  
                     ],
-  function( alpha )
+  function( cat, alpha )
     local a, I_a;
     
     a := Source( alpha );
@@ -71,7 +71,7 @@ AddFinalDerivation( IsColiftableThroughColiftingObject,
                       IsColiftableThroughColiftingObject,
                       MorphismIntoColiftingObject  
                     ],
-  IsNullHomotopic : CategoryFilter := IsChainOrCochainComplexCategory,
+  { cat, alpha } -> IsNullHomotopic( alpha ) : CategoryFilter := IsChainOrCochainComplexCategory,
       Description:= "IsColiftableThroughColiftingObject by IsNullHomotopic"
       );
 

--- a/HomotopyCategories/tst/050_LoadPackage.tst
+++ b/HomotopyCategories/tst/050_LoadPackage.tst
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# HomotopyCategories: Homotopy categories of additive categories
-#
-# This file tests if the package can be loaded without errors or warnings.
-#
-
-gap> LoadPackage( "FreydCategoriesForCAP", false );
-#I  method installed for IsInjective matches more than one declaration
-true

--- a/StableCategories/PackageInfo.g
+++ b/StableCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "StableCategories",
 Subtitle := "Stable categories of additive categories",
-Version := "2020.11-01",
+Version := "2021.03-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -70,7 +70,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.8",
-  NeededOtherPackages := [ [ "CAP", ">= 2020.04.27" ],
+  NeededOtherPackages := [ [ "CAP", ">= 2021.03-01" ],
                            [ "GAPDoc", ">= 1.5" ],
                             #[ "TriangulatedCategories", ">= 2020.07.15" ],
                             #[ "FrobeniusCategories", ">= 2019.12.06" ],

--- a/StableCategories/gap/DerivedMethods.gi
+++ b/StableCategories/gap/DerivedMethods.gi
@@ -11,7 +11,7 @@ AddDerivationToCAP( IsLiftableThroughLiftingObject,
                     [ MorphismFromLiftingObject,  1 ]
                 ],
     
-  function( alpha )
+  function( cat, alpha )
     local b, P_b;
     
     b := Range( alpha );
@@ -30,7 +30,7 @@ AddDerivationToCAP( IsLiftableThroughLiftingObject,
                     [ MorphismFromLiftingObject,  1 ]
                 ],
     
-  function( alpha )
+  function( cat, alpha )
     local b, P_b;
     
     b := Range( alpha );
@@ -48,7 +48,7 @@ AddDerivationToCAP( WitnessForBeingLiftableThroughLiftingObject,
                     [ MorphismFromLiftingObject,  1 ]
                 ],
     
-  function( alpha )
+  function( cat, alpha )
     local b, P_b;
     
     b := Range( alpha );
@@ -68,7 +68,7 @@ AddDerivationToCAP( IsColiftableThroughColiftingObject,
                     [ MorphismIntoColiftingObject,  1 ]
                 ],
   
-  function( alpha )
+  function( cat, alpha )
     local a, I_a;
     
     a := Source( alpha );
@@ -87,7 +87,7 @@ AddDerivationToCAP( IsColiftableThroughColiftingObject,
                     [ MorphismIntoColiftingObject,  1 ]
                 ],
     
-  function( alpha )
+  function( cat, alpha )
     local a, I_a;
     
     a := Source( alpha );
@@ -105,7 +105,7 @@ AddDerivationToCAP( WitnessForBeingColiftableThroughColiftingObject,
                     [ MorphismIntoColiftingObject,  1 ]
                 ],
     
-  function( alpha )
+  function( cat, alpha )
     local a, I_a;
     
     a := Source( alpha );

--- a/StableCategories/gap/StableCategories.gi
+++ b/StableCategories/gap/StableCategories.gi
@@ -48,87 +48,87 @@ InstallValue( STABLE_CATEGORIES_METHOD_NAME_RECORD, rec(
 
 IsLiftingObject := rec(
   installation_name := "IsLiftingObject",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   cache_name := "IsLiftingObject",
   return_type := "bool" ),
 
 LiftingObject := rec(
   installation_name := "LiftingObject",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   cache_name := "LiftingObject",
   return_type := "object" ),
 
 LiftingMorphismWithGivenLiftingObjects := rec(
     installation_name := "LiftingMorphismWithGivenLiftingObjects",
-    filter_list := [ "morphism", "object", "object" ],
+    filter_list := [ "category", "morphism", "object", "object" ],
     cache_name := "LiftingMorphismWithGivenLiftingObjects",
     return_type := "morphism" ),
     
 MorphismFromLiftingObjectWithGivenLiftingObject := rec(
   installation_name := "MorphismFromLiftingObjectWithGivenLiftingObject",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   cache_name := "MorphismFromLiftingObjectWithGivenLiftingObject",
   number_of_diagram_arguments := 1,
   return_type := "morphism" ),
 
 MorphismFromLiftingObject := rec(
   installation_name := "MorphismFromLiftingObject",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   cache_name := "MorphismFromLiftingObject",
   return_type := "morphism" ),
 
 IsLiftableThroughLiftingObject := rec(
   installation_name := "IsLiftableThroughLiftingObject",
-  filter_list := [ "morphism" ],
+  filter_list := [ "category", "morphism" ],
   cache_name := "IsLiftableThroughLiftingObject",
   return_type := "bool" ),
 
 WitnessForBeingLiftableThroughLiftingObject := rec(
   installation_name := "WitnessForBeingLiftableThroughLiftingObject",
-  filter_list := [ "morphism" ],
+  filter_list := [ "category", "morphism" ],
   cache_name := "WitnessForBeingLiftableThroughLiftingObject",
   return_type := "morphism" ),
 
 IsColiftingObject := rec(
   installation_name := "IsColiftingObject",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   cache_name := "IsColiftingObject",
   return_type := "bool" ),
 
 ColiftingObject := rec(
   installation_name := "ColiftingObject",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   cache_name := "ColiftingObject",
   return_type := "object" ),
 
 ColiftingMorphismWithGivenColiftingObjects := rec(
   installation_name := "ColiftingMorphismWithGivenColiftingObjects",
-  filter_list := [ "morphism", "object", "object" ],
+  filter_list := [ "category", "morphism", "object", "object" ],
   cache_name := "ColiftingMorphismWithGivenColiftingObjects",
   return_type := "morphism" ),
   
 MorphismIntoColiftingObjectWithGivenColiftingObject := rec(
   installation_name := "MorphismIntoColiftingObjectWithGivenColiftingObject",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   cache_name := "MorphismIntoColiftingObjectWithGivenColiftingObject",
   number_of_diagram_arguments := 1,
   return_type := "morphism" ),
 
 MorphismIntoColiftingObject := rec(
   installation_name := "MorphismIntoColiftingObject",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   cache_name := "MorphismIntoColiftingObject",
   return_type := "morphism" ),
 
 IsColiftableThroughColiftingObject := rec(
   installation_name := "IsColiftableThroughColiftingObject",
-  filter_list := [ "morphism" ],
+  filter_list := [ "category", "morphism" ],
   cache_name := "IsColiftableThroughColiftingObject",
   return_type := "bool" ),
 
 WitnessForBeingColiftableThroughColiftingObject := rec(
   installation_name := "WitnessForBeingColiftableThroughColiftingObject",
-  filter_list := [ "morphism" ],
+  filter_list := [ "category", "morphism" ],
   cache_name := "WitnessForBeingColiftableThroughColiftingObject",
   return_type := "morphism" ),
 

--- a/ToolsForHigherHomologicalAlgebra/gap/CAP.gi
+++ b/ToolsForHigherHomologicalAlgebra/gap/CAP.gi
@@ -182,7 +182,7 @@ end, 5000 );
 
 ##
 InstallMethod( SimplifySource,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -199,11 +199,11 @@ InstallMethod( SimplifySource,
     
     return PreCompose( SimplifyObject_IsoToInputObject( Source( phi ), i ), phi );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifySource_IsoFromInputObject,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -220,11 +220,11 @@ InstallMethod( SimplifySource_IsoFromInputObject,
     
     return SimplifyObject_IsoFromInputObject( Source( phi ), i );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifySource_IsoToInputObject,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -241,11 +241,11 @@ InstallMethod( SimplifySource_IsoToInputObject,
     
     return SimplifyObject_IsoToInputObject( Source( phi ), i );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifyRange,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -262,11 +262,11 @@ InstallMethod( SimplifyRange,
     
     return PreCompose( phi, SimplifyObject_IsoFromInputObject( Range( phi ), i ) );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifyRange_IsoFromInputObject,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -283,11 +283,11 @@ InstallMethod( SimplifyRange_IsoFromInputObject,
     
     return SimplifyObject_IsoFromInputObject( Range( phi ), i );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifyRange_IsoToInputObject,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -304,11 +304,11 @@ InstallMethod( SimplifyRange_IsoToInputObject,
     
     return SimplifyObject_IsoToInputObject( Range( phi ), i );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifySourceAndRange,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -331,11 +331,11 @@ InstallMethod( SimplifySourceAndRange,
               ]
             );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifySourceAndRange_IsoFromInputSource,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -352,11 +352,11 @@ InstallMethod( SimplifySourceAndRange_IsoFromInputSource,
     
     return SimplifyObject_IsoFromInputObject( Source( phi ), i );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifySourceAndRange_IsoToInputSource,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -373,11 +373,11 @@ InstallMethod( SimplifySourceAndRange_IsoToInputSource,
     
     return SimplifyObject_IsoToInputObject( Source( phi ), i );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifySourceAndRange_IsoFromInputRange,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -394,11 +394,11 @@ InstallMethod( SimplifySourceAndRange_IsoFromInputRange,
     
     return SimplifyObject_IsoFromInputObject( Range( phi ), i );
     
-end, -1 );
+end );
 
 ##
 InstallMethod( SimplifySourceAndRange_IsoToInputRange,
-          [ IsCapCategoryMorphism, IsObject ],
+          [ IsCapCategoryMorphism, IsObject ], -1,
           
   function( phi, i )
     local category;
@@ -415,4 +415,4 @@ InstallMethod( SimplifySourceAndRange_IsoToInputRange,
     
     return SimplifyObject_IsoToInputObject( Range( phi ), i );
     
-end, -1 );
+end );

--- a/ToolsForHigherHomologicalAlgebra/tst/050_LoadPackage.tst
+++ b/ToolsForHigherHomologicalAlgebra/tst/050_LoadPackage.tst
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# ToolsForHigherHomologicalAlgebra: Tools for the Higher Homological Algebra project
-#
-# This file tests if the package can be loaded without errors or warnings.
-#
-
-gap> LoadPackage( "FreydCategoriesForCAP", false );
-#I  method installed for IsInjective matches more than one declaration
-true

--- a/TriangulatedCategories/PackageInfo.g
+++ b/TriangulatedCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "TriangulatedCategories",
 Subtitle := "Framework for triangulated categories",
-Version := "2020.11-04",
+Version := "2021.03-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -70,7 +70,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.8",
-  NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ], [ "CAP", ">= 2020.04.27" ] ],
+  NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ], [ "CAP", ">= 2021.03-01" ] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],
 ),

--- a/TriangulatedCategories/gap/DerivedMethods.gi
+++ b/TriangulatedCategories/gap/DerivedMethods.gi
@@ -15,7 +15,7 @@ AddDerivationToCAP( IsExactTriangle,
                 [
                   [ WitnessIsomorphismOntoStandardConeObject, 1 ],
                 ],
-  function( alpha, iota, pi )
+  function( cat, alpha, iota, pi )
     
     return WitnessIsomorphismOntoStandardConeObject( alpha, iota, pi ) <> fail;
     
@@ -34,7 +34,7 @@ AddFinalDerivation( WitnessIsomorphismOntoStandardConeObject,
                   WitnessIsomorphismOntoStandardConeObject,
                   WitnessIsomorphismFromStandardConeObject
                 ],
-  function( alpha, iota, pi )
+  function( cat, alpha, iota, pi )
     local iota_alpha, pi_alpha, left_coeffs, right_coeffs, right_side, sol;
     
     if not IsEqualForObjects( ShiftOnObject( Source( alpha ) ), Range( pi ) ) then
@@ -68,7 +68,7 @@ AddFinalDerivation( WitnessIsomorphismOntoStandardConeObject,
   end,
 [
   WitnessIsomorphismFromStandardConeObject,
-    function( alpha, iota, pi )
+    function( cat, alpha, iota, pi )
       local w;
       
       w := WitnessIsomorphismOntoStandardConeObject( alpha, iota, pi );
@@ -98,7 +98,7 @@ AddFinalDerivation( IsIsomorphism,
                 [
                     IsIsomorphism
                 ],
-  function( alpha )
+  function( cat, alpha )
   
     return IsZeroForObjects( StandardConeObject( alpha ) );
     
@@ -113,7 +113,7 @@ AddDerivationToCAP( DomainMorphismByOctahedralAxiomWithGivenObjects,
                     [ IdentityMorphism, 1 ],
                     [ MorphismBetweenStandardConeObjectsWithGivenObjects,  1 ]
                 ],
-  function( s, alpha, beta, gamma, r )
+  function( cat, s, alpha, beta, gamma, r )
     local A, id_A;
     
     A := Source( alpha );
@@ -132,7 +132,7 @@ AddDerivationToCAP( MorphismFromConeObjectByOctahedralAxiomWithGivenObjects,
                   [ ShiftOnObject, 1 ],
                   [ ShiftOnMorphismWithGivenObjects, 1 ]
                 ],
-  function( s, alpha, beta, gamma, r )
+  function( cat, s, alpha, beta, gamma, r )
     local B, pi_beta, cone_alpha, iota_alpha;
     
     B := Range( alpha );
@@ -164,7 +164,7 @@ AddDerivationToCAP( IsSplitEpimorphism,
                 [
                     [ IsEpimorphism, 1 ]
                 ],
-  function( alpha )
+  function( cat, alpha )
     return IsEpimorphism( alpha );
 end:
   CategoryFilter := IsTriangulatedCategory,
@@ -176,7 +176,7 @@ AddDerivationToCAP( IsSplitMonomorphism,
                 [
                     [ IsMonomorphism, 1 ]
                 ],
-  function( alpha )
+  function( cat, alpha )
     return IsMonomorphism( alpha );
 end:
   CategoryFilter := IsTriangulatedCategory,
@@ -188,7 +188,7 @@ AddDerivationToCAP( IsEpimorphism,
                 [
                     [ IsSplitEpimorphism, 1 ]
                 ],
-  function( alpha )
+  function( cat, alpha )
     return IsSplitEpimorphism( alpha );
 end:
   CategoryFilter := IsTriangulatedCategory,
@@ -200,7 +200,7 @@ AddDerivationToCAP( IsMonomorphism,
                 [
                     [ IsSplitMonomorphism, 1 ]
                 ],
-  function( alpha )
+  function( cat, alpha )
     return IsSplitMonomorphism( alpha );
 end:
   CategoryFilter := IsTriangulatedCategory,
@@ -213,7 +213,7 @@ AddDerivationToCAP( ShiftFactoringIsomorphismWithGivenObjects,
                     [ InjectionOfCofactorOfDirectSum, 1 ],
                     [ ShiftOnMorphismWithGivenObjects, 1 ]
                 ],
-  function( s, L, r  )
+  function( cat, s, L, r  )
     local l, Tl;
 
     l := List( [ 1..Length( L ) ], i -> InjectionOfCofactorOfDirectSum( L , i ) );
@@ -230,7 +230,7 @@ AddDerivationToCAP( ShiftExpandingIsomorphismWithGivenObjects,
                     [ ProjectionInFactorOfDirectSum, 1 ],
                     [ ShiftOnMorphismWithGivenObjects, 1 ]
                 ],
-  function( s, L, r  )
+  function( cat, s, L, r  )
     local l, Tl;
 
     l := List( [ 1..Length( L ) ], i -> ProjectionInFactorOfDirectSum( L , i ) );
@@ -249,7 +249,7 @@ AddDerivationToCAP( InverseShiftFactoringIsomorphismWithGivenObjects,
                     [ InjectionOfCofactorOfDirectSum, 1 ],
                     [ InverseShiftOnMorphismWithGivenObjects, 1 ]
                 ],
-  function( s, L, r )
+  function( cat, s, L, r )
     local l, Tl;
 
     l := List( [ 1..Length( L ) ], i -> InjectionOfCofactorOfDirectSum( L , i ) );
@@ -267,7 +267,7 @@ AddDerivationToCAP( InverseShiftExpandingIsomorphismWithGivenObjects,
                     [ ProjectionInFactorOfDirectSum, 1 ],
                     [ InverseShiftOnMorphismWithGivenObjects, 1 ]
                 ],
-  function( s, L, r )
+  function( cat, s, L, r )
     local l, Tl;
 
     l := List( [ 1..Length( L ) ], i -> ProjectionInFactorOfDirectSum( L , i ) );

--- a/TriangulatedCategories/gap/TriangulatedCategories.gi
+++ b/TriangulatedCategories/gap/TriangulatedCategories.gi
@@ -14,14 +14,14 @@ InstallValue( TRIANGULATED_CATEGORIES_METHOD_NAME_RECORD, rec(
 
 StandardConeObject:= rec(
   installation_name := "StandardConeObject",
-  filter_list := [ "morphism" ],
+  filter_list := [ "category", "morphism" ],
   cache_name := "StandardConeObject",
   return_type := "object"
 ),
 
 MorphismIntoStandardConeObjectWithGivenStandardConeObject := rec(
   installation_name := "MorphismIntoStandardConeObjectWithGivenStandardConeObject",
-  filter_list := [ "morphism", "object" ],
+  filter_list := [ "category", "morphism", "object" ],
   io_type := [ [ "alpha", "cone_alpha" ], [ "range_alpha", "cone_alpha" ] ],
   number_of_diagram_arguments := 1,
   cache_name := "MorphismIntoStandardConeObjectWithGivenStandardConeObject",
@@ -30,7 +30,7 @@ MorphismIntoStandardConeObjectWithGivenStandardConeObject := rec(
 
 MorphismFromStandardConeObjectWithGivenStandardConeObject := rec(
   installation_name := "MorphismFromStandardConeObjectWithGivenStandardConeObject",
-  filter_list := [ "morphism", "object" ],
+  filter_list := [ "category", "morphism", "object" ],
   io_type := [ [ "alpha", "cone_alpha" ], [ "cone_alpha", "sh_source_alpha" ] ],
   number_of_diagram_arguments := 1,  
   cache_name := "MorphismFromStandardConeObjectWithGivenStandardConeObject",
@@ -39,7 +39,7 @@ MorphismFromStandardConeObjectWithGivenStandardConeObject := rec(
 
 MorphismIntoStandardConeObject := rec(
   installation_name := "MorphismIntoStandardConeObject",
-  filter_list := [ "morphism" ],
+  filter_list := [ "category", "morphism" ],
   io_type := [ [ "alpha" ], [ "range_alpha", "cone_alpha" ] ],
   cache_name := "MorphismIntoStandardConeObject",
   return_type := "morphism"
@@ -47,7 +47,7 @@ MorphismIntoStandardConeObject := rec(
 
 MorphismFromStandardConeObject := rec(
   installation_name := "MorphismFromStandardConeObject",
-  filter_list := [ "morphism" ],
+  filter_list := [ "category", "morphism" ],
   io_type := [ [ "alpha" ], [ "cone_alpha", "sh_source_alpha" ] ],
   cache_name := "MorphismFromStandardConeObject",
   return_type := "morphism"
@@ -55,7 +55,7 @@ MorphismFromStandardConeObject := rec(
 
 ShiftOnObject:= rec(
   installation_name := "ShiftOnObject",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   cache_name := "ShiftOnObject",
   return_type := "object"
 ),
@@ -63,14 +63,14 @@ ShiftOnObject:= rec(
 ShiftOnMorphismWithGivenObjects := rec(
   installation_name := "ShiftOnMorphismWithGivenObjects",
   io_type := [ [ "s", "alpha", "r" ], [ "s", "r" ] ],
-  filter_list := [ "object", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "object" ],
   cache_name := "ShiftOnMorphismWithGivenObjects",
   return_type := "morphism"
 ),
 
 InverseShiftOnObject := rec(
   installation_name := "InverseShiftOnObject",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   cache_name := "InverseShiftOnObject",
   return_type := "object"
 ),
@@ -78,7 +78,7 @@ InverseShiftOnObject := rec(
 InverseShiftOnMorphismWithGivenObjects := rec(
   installation_name := "InverseShiftOnMorphismWithGivenObjects",
   io_type := [ [ "s", "alpha", "r" ], [ "s", "r" ] ],
-  filter_list := [ "object", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "object" ],
   cache_name := "InverseShiftOnMorphismWithGivenObjects",
   return_type := "morphism"
 ),
@@ -86,7 +86,7 @@ InverseShiftOnMorphismWithGivenObjects := rec(
 WitnessIsomorphismOntoStandardConeObject := rec(
   installation_name := "WitnessIsomorphismOntoStandardConeObject",
   io_type := [ [ "alpha", "iota", "pi" ], [ "range_iota", "cone_alpha" ] ],
-  filter_list := [ "morphism", "morphism", "morphism" ],
+  filter_list := [ "category", "morphism", "morphism", "morphism" ],
   cache_name := "WitnessIsomorphismOntoStandardConeObject",
   return_type := "morphism_or_fail"
 ),
@@ -94,21 +94,21 @@ WitnessIsomorphismOntoStandardConeObject := rec(
 WitnessIsomorphismFromStandardConeObject := rec(
   installation_name := "WitnessIsomorphismFromStandardConeObject",
   io_type := [ [ "alpha", "iota", "pi" ], [ "cone_alpha", "range_iota" ] ],
-  filter_list := [ "morphism", "morphism", "morphism" ],
+  filter_list := [ "category", "morphism", "morphism", "morphism" ],
   cache_name := "WitnessIsomorphismFromStandardConeObject",
   return_type := "morphism_or_fail"
 ),
 
 IsExactTriangle := rec(
   installation_name := "IsExactTriangle",
-  filter_list := [ "morphism", "morphism", "morphism" ],
+  filter_list := [ "category", "morphism", "morphism", "morphism" ],
   cache_name := "IsExactTriangle",
   return_type := "bool"
 ),
 
 UnitIsomorphismWithGivenObject := rec(
   installation_name := "UnitIsomorphismWithGivenObject",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   io_type := [ [ "s", "sh_o_rev_sh_s" ], [ "s", "alpha", "sh_o_rev_sh_s" ] ],
   cache_name := "UnitIsomorphismWithGivenObject",
   return_type := "morphism"
@@ -116,7 +116,7 @@ UnitIsomorphismWithGivenObject := rec(
 
 #UnitIsomorphism := rec(
 #  installation_name := "UnitIsomorphism",
-#  filter_list := [ "object" ],
+#  filter_list := [ "category", "object" ],
 #  io_type := [ [ "s" ], [ "s", "alpha", "sh_o_rev_sh_s" ] ],
 #  cache_name := "UnitIsomorphism",
 #  return_type := "morphism"
@@ -124,7 +124,7 @@ UnitIsomorphismWithGivenObject := rec(
 
 InverseOfCounitIsomorphismWithGivenObject := rec(
   installation_name := "InverseOfCounitIsomorphismWithGivenObject",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   io_type := [ [ "s", "rev_sh_o_sh_s" ], [ "s", "alpha", "rev_sh_o_sh_s" ] ],
   cache_name := "InverseOfCounitIsomorphismWithGivenObject",
   return_type := "morphism"
@@ -132,7 +132,7 @@ InverseOfCounitIsomorphismWithGivenObject := rec(
 
 #InverseOfCounitIsomorphism := rec(
 #  installation_name := "InverseOfCounitIsomorphism",
-#  filter_list := [ "object" ],
+#  filter_list := [ "category", "object" ],
 #  io_type := [ [ "s" ], [ "s", "alpha", "rev_sh_o_sh_s" ] ],
 #  cache_name := "InverseOfCounitIsomorphism",
 #  return_type := "morphism"
@@ -140,7 +140,7 @@ InverseOfCounitIsomorphismWithGivenObject := rec(
 
 InverseOfUnitIsomorphismWithGivenObject := rec(
   installation_name := "InverseOfUnitIsomorphismWithGivenObject",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   io_type := [ [ "s", "sh_o_rev_sh_s" ], [ "sh_o_rev_sh_s", "alpha", "s" ] ],
   cache_name := "InverseOfUnitIsomorphismWithGivenObject",
   return_type := "morphism"
@@ -148,7 +148,7 @@ InverseOfUnitIsomorphismWithGivenObject := rec(
 
 #InverseOfUnitIsomorphism := rec(
 #  installation_name := "InverseOfUnitIsomorphism",
-#  filter_list := [ "object" ],
+#  filter_list := [ "category", "object" ],
 #  io_type := [ [ "s" ], [ "sh_o_rev_sh_s", "alpha", "s" ] ],
 #  cache_name := "InverseOfUnitIsomorphism",
 #  return_type := "morphism"
@@ -156,7 +156,7 @@ InverseOfUnitIsomorphismWithGivenObject := rec(
 
 CounitIsomorphismWithGivenObject := rec(
   installation_name := "CounitIsomorphismWithGivenObject",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   io_type := [ [ "s", "rev_sh_o_sh_s" ], [ "rev_sh_o_sh_s", "alpha", "s" ] ],
   cache_name := "CounitIsomorphismWithGivenObject",
   return_type := "morphism"
@@ -164,12 +164,13 @@ CounitIsomorphismWithGivenObject := rec(
 
 #CounitIsomorphism := rec(
 #  installation_name := "CounitIsomorphism",
-#  filter_list := [ "object" ],
+#  filter_list := [ "category", "object" ],
 #  io_type := [ [ "s" ], [ "rev_sh_o_sh_s", "alpha", "s" ] ],
 #  cache_name := "CounitIsomorphism",
 #  return_type := "morphism"
 #),
 
+# this cannot have the category as the first argument due to GAP only supporting operations with at most 6 arguments :-(
 MorphismBetweenStandardConeObjectsWithGivenObjects := rec(
   installation_name := "MorphismBetweenStandardConeObjectsWithGivenObjects",
   filter_list := [ "object", "morphism", "morphism", "morphism", "morphism", "object" ],
@@ -181,28 +182,28 @@ MorphismBetweenStandardConeObjectsWithGivenObjects := rec(
 
 DomainMorphismByOctahedralAxiomWithGivenObjects := rec(
   installation_name := "DomainMorphismByOctahedralAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "morphism", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "morphism", "morphism", "object" ],
   cache_name := "DomainMorphismByOctahedralAxiomWithGivenObjects",
   return_type := "morphism",
 ),
 
 MorphismIntoConeObjectByOctahedralAxiomWithGivenObjects := rec(
   installation_name := "MorphismIntoConeObjectByOctahedralAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "morphism", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "morphism", "morphism", "object" ],
   cache_name := "MorphismIntoConeObjectByOctahedralAxiomWithGivenObjects",
   return_type := "morphism",
 ),
 
 MorphismFromConeObjectByOctahedralAxiomWithGivenObjects := rec(
   installation_name := "MorphismFromConeObjectByOctahedralAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "morphism", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "morphism", "morphism", "object" ],
   cache_name := "MorphismFromConeObjectByOctahedralAxiomWithGivenObjects",
   return_type := "morphism",
 ),
 
 WitnessIsomorphismOntoStandardConeObjectByOctahedralAxiomWithGivenObjects := rec(
   installation_name := "WitnessIsomorphismOntoStandardConeObjectByOctahedralAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "morphism", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "morphism", "morphism", "object" ],
   io_type := [ [ "cone_g", "f", "g", "h", "st_cone" ], [ "cone_g", "st_cone" ] ],
   cache_name := "WitnessIsomorphismOntoStandardConeObjectByOctahedralAxiomWithGivenObjects",
   return_type := "morphism",
@@ -210,7 +211,7 @@ WitnessIsomorphismOntoStandardConeObjectByOctahedralAxiomWithGivenObjects := rec
 
 WitnessIsomorphismFromStandardConeObjectByOctahedralAxiomWithGivenObjects := rec(
   installation_name := "WitnessIsomorphismFromStandardConeObjectByOctahedralAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "morphism", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "morphism", "morphism", "object" ],
   io_type := [ [ "st_cone", "f", "g", "h", "cone_g" ], [ "st_cone", "cone_g" ] ],
   cache_name := "WitnessIsomorphismFromStandardConeObjectByOctahedralAxiomWithGivenObjects",
   return_type := "morphism",
@@ -218,7 +219,7 @@ WitnessIsomorphismFromStandardConeObjectByOctahedralAxiomWithGivenObjects := rec
 
 WitnessIsomorphismOntoStandardConeObjectByRotationAxiomWithGivenObjects := rec(
   installation_name := "WitnessIsomorphismOntoStandardConeObjectByRotationAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "object" ],
   io_type := [ [ "cone", "f", "st_cone" ], [ "cone", "st_cone" ] ],
   cache_name := "WitnessIsomorphismOntoStandardConeObjectByRotationAxiomWithGivenObjects",
   return_type := "morphism",
@@ -226,7 +227,7 @@ WitnessIsomorphismOntoStandardConeObjectByRotationAxiomWithGivenObjects := rec(
 
 WitnessIsomorphismFromStandardConeObjectByRotationAxiomWithGivenObjects := rec(
   installation_name := "WitnessIsomorphismFromStandardConeObjectByRotationAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "object" ],
   io_type := [ [ "st_cone", "f", "cone" ], [ "st_cone", "cone" ] ],
   cache_name := "WitnessIsomorphismFromStandardConeObjectByRotationAxiomWithGivenObjects",
   return_type := "morphism",
@@ -234,7 +235,7 @@ WitnessIsomorphismFromStandardConeObjectByRotationAxiomWithGivenObjects := rec(
 
 WitnessIsomorphismOntoStandardConeObjectByInverseRotationAxiomWithGivenObjects := rec(
   installation_name := "WitnessIsomorphismOntoStandardConeObjectByInverseRotationAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "object" ],
   io_type := [ [ "cone", "f", "st_cone" ], [ "cone", "st_cone" ] ],
   cache_name := "WitnessIsomorphismOntoStandardConeObjectByInverseRotationAxiomWithGivenObjects",
   return_type := "morphism",
@@ -242,7 +243,7 @@ WitnessIsomorphismOntoStandardConeObjectByInverseRotationAxiomWithGivenObjects :
 
 WitnessIsomorphismFromStandardConeObjectByInverseRotationAxiomWithGivenObjects := rec(
   installation_name := "WitnessIsomorphismFromStandardConeObjectByInverseRotationAxiomWithGivenObjects",
-  filter_list := [ "object", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "object" ],
   io_type := [ [ "st_cone", "f", "cone" ], [ "st_cone", "cone" ] ],
   cache_name := "WitnessIsomorphismFromStandardConeObjectByInverseRotationAxiomWithGivenObjects",
   return_type := "morphism",
@@ -250,7 +251,7 @@ WitnessIsomorphismFromStandardConeObjectByInverseRotationAxiomWithGivenObjects :
 
 ShiftExpandingIsomorphismWithGivenObjects := rec(
   installation_name := "ShiftExpandingIsomorphismWithGivenObjects",
-  filter_list := [ "object", IsList, "object" ],
+  filter_list := [ "category", "object", IsList, "object" ],
   io_type := [ [ "s", "L", "r" ], [ "s", "r" ] ],
   cache_name := "ShiftExpandingIsomorphismWithGivenObjects",
   return_type := "morphism"
@@ -258,7 +259,7 @@ ShiftExpandingIsomorphismWithGivenObjects := rec(
 
 ShiftFactoringIsomorphismWithGivenObjects := rec(
   installation_name := "ShiftFactoringIsomorphismWithGivenObjects",
-  filter_list := [ "object", IsList, "object" ],
+  filter_list := [ "category", "object", IsList, "object" ],
   io_type := [ [ "s", "L", "r" ], [ "s", "r" ] ],
   cache_name := "ShiftFactoringIsomorphismWithGivenObjects",
   return_type := "morphism"
@@ -266,7 +267,7 @@ ShiftFactoringIsomorphismWithGivenObjects := rec(
 
 InverseShiftExpandingIsomorphismWithGivenObjects := rec(
   installation_name := "InverseShiftExpandingIsomorphismWithGivenObjects",
-  filter_list := [ "object", IsList, "object" ],
+  filter_list := [ "category", "object", IsList, "object" ],
   io_type := [ [ "s", "L", "r" ], [ "s", "r" ] ],
   cache_name := "InverseShiftExpandingIsomorphismWithGivenObjects",
   return_type := "morphism"
@@ -274,7 +275,7 @@ InverseShiftExpandingIsomorphismWithGivenObjects := rec(
 
 InverseShiftFactoringIsomorphismWithGivenObjects := rec(
   installation_name := "InverseShiftFactoringIsomorphismWithGivenObjects",
-  filter_list := [ "object", IsList, "object" ],
+  filter_list := [ "category", "object", IsList, "object" ],
   io_type := [ [ "s", "L", "r" ], [ "s", "r" ] ],
   cache_name := "InverseShiftFactoringIsomorphismWithGivenObjects",
   return_type := "morphism"

--- a/TriangulatedCategories/tst/050_LoadPackage.tst
+++ b/TriangulatedCategories/tst/050_LoadPackage.tst
@@ -5,5 +5,4 @@
 #
 
 gap> LoadPackage( "DerivedCategories", false );
-#I  method installed for IsInjective matches more than one declaration
 true

--- a/make_dist.sh
+++ b/make_dist.sh
@@ -7,5 +7,5 @@ packages="BBGG Bicomplexes ComplexesCategories DerivedCategories HomotopyCategor
 base_dir="$PWD"
 
 for pkg in ${packages}; do
-  ./release-gap-package --skip-existing-release --srcdir ${base_dir}/${pkg} --webdir ${base_dir}/gh-pages/${pkg} --update-file ${base_dir}/gh-pages/update.g $@
+  ./release-gap-package --skip-existing-release --srcdir ${base_dir}/${pkg} --webdir ${base_dir}/gh-pages/${pkg} --update-script ${base_dir}/gh-pages/update.g $@
 done

--- a/release-gap-package
+++ b/release-gap-package
@@ -43,12 +43,13 @@ Actions
   -p,  --push                      perform the final push, completing the release [Default]
   -P,  --no-push                   do not perform the final push
   -f,  --force                     if a release with the same name already exists: overwrite it
+  --skip-existing-release          if a release with the same name already exists: exit without error
 
 Paths
   --srcdir <path>                  path of directory containing PackageInfo.g [Default: current directory]
   --tmpdir <path>                  path of temporary directory [Default: tmp subdirectory of srcdir]
   --webdir <path>                  path of web directory [Default: gh-pages subdirectory of srcdir]
-  --update-file <file>             path of the update.g file [Default: update.g in webdir]
+  --update-script <file>           path of the update script [Default: update.g in webdir]
 
 Custom settings
   --token <oauth>                  GitHub access token
@@ -145,12 +146,12 @@ while [ x"$1" != x ]; do
     --srcdir ) SRC_DIR="$1"; shift ;;
     --webdir ) WEB_DIR="$1"; shift ;;
     --tmpdir ) TMP_DIR="$1"; shift ;;
-    --update-file ) UPDATE_FILE="$1"; shift ;;
+    --update-script ) UPDATE_SCRIPT="$1"; shift ;;
 
     --srcdir=*) SRC_DIR=${option#--srcdir=}; shift ;;
     --webdir=*) WEB_DIR=${option#--webdir=}; shift ;;
     --tmpdir=*) TMP_DIR=${option#--tmpdir=}; shift ;;
-    --update-file=*) UPDATE_FILE=${option#--update-file=}; shift ;;
+    --update-script=*) UPDATE_SCRIPT=${option#--update-script=}; shift ;;
 
     --token ) TOKEN="$1"; shift ;;
 
@@ -189,12 +190,12 @@ if [ ! -d "$WEB_DIR" ] ; then
     error "could not find 'webdir' with clone of your gh-pages branch"
 fi
 
-# Check for presence of update.g file
-if [ "x$UPDATE_FILE" = x ] ; then
-    UPDATE_FILE="$WEB_DIR/update.g"
+# Check for presence of the update script
+if [ "x$UPDATE_SCRIPT" = x ] ; then
+    UPDATE_SCRIPT="$WEB_DIR/update.g"
 fi
-if [ ! -f "$UPDATE_FILE" ] ; then
-    error "could not find update.g file"
+if [ ! -f "$UPDATE_SCRIPT" ] ; then
+    error "could not find update script \"${UPDATE_SCRIPT}\""
 fi
 
 # Check whether GAP is usable
@@ -416,8 +417,8 @@ sed "s;Date := .*;Date := \"$(date +%d/%m/%Y)\",;" PackageInfo.g > PackageInfo.g
 mv PackageInfo.g.bak PackageInfo.g
 
 notice "Removing unnecessary files"
-rm -rf .github .circleci
-rm -f .git* .hg* .cvs*
+# Remove recursively in case there is a .github directory
+rm -rf .git* .hg* .cvs* .circleci
 rm -f .appveyor.yml .codecov.yml .travis.yml
 
 # execute .release script, if present
@@ -447,7 +448,7 @@ fi;
 PushOptions(rec(relativePath:="../../.."));
 Read("makedoc.g");
 GAPInput
-    rm -f doc/*.lab doc/*.tex
+    rm -f doc/*.tex
     rm -f doc/*.aux doc/*.bbl doc/*.blg doc/*.brf doc/*.idx doc/*.ilg doc/*.ind doc/*.log doc/*.out doc/*.pnr doc/*.tst
 elif [ -f doc/make_doc ] ; then
     notice "Copying GAP package documentation for archives (using doc/make_doc)"
@@ -565,7 +566,7 @@ fi
 DATA=$(cat <<EOF
 {
   "tag_name": "$TAG",
-  "name": "$PKG-$VERSION",
+  "name": "$PKG $VERSION",
   "body": "Release for $PKG",
   "draft": false,
   "prerelease": false
@@ -627,7 +628,7 @@ if [ ! -f "$FULLNAME" ] ; then
 	error "could not find PDF"
 fi
 notice "Uploading PDF"
-response=$(curl --fail --progress-bar -o "$TMP_DIR/upload.log" \
+response=$(curl --fail --progress-bar -o "$TMP_DIR/upload_pdf.log" \
 	-X POST "$UPLOAD_URL/$RELEASE_ID/assets?name=$BASENAME.pdf" \
 	-H "Accept: application/vnd.github.v3+json" \
 	-H "Authorization: token $TOKEN" \
@@ -666,7 +667,7 @@ for f in ./*/*.htm* ; do
 done
 
 run_gap <<GAPInput
-Read("$UPDATE_FILE");
+Read("$UPDATE_SCRIPT");
 GAPInput
 
 git add -A


### PR DESCRIPTION
Only a subset of the changes are needed for compatibility with the CAP PR, but I decided to update all method records anyway. Note that MorphismBetweenStandardConeObjectsWithGivenObjects cannot get the category as the first argument as GAP does not allow operations with more than six arguments :-(