### PR TITLE
Adjust to https://github.com/homalg-project/CAP_project/pull/731

### DIFF
--- a/StableCategories/PackageInfo.g
+++ b/StableCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "StableCategories",
 Subtitle := "Stable categories of additive categories",
-Version := "2021.10-01",
+Version := "2021.10-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/StableCategories/gap/FrobeniusCategories.gi
+++ b/StableCategories/gap/FrobeniusCategories.gi
@@ -94,7 +94,6 @@ return_type := "object" ),
 ExactCokernelProjection := rec(
 io_type := [ [ "iota" ], [ "iota_range", "K" ] ],
 with_given_object_position := "Range",
-universal_type := "Colimit",
 filter_list := [ "category", "morphism" ],
 return_type := "morphism" ),
 
@@ -122,7 +121,6 @@ return_type := "object" ),
 ExactKernelEmbedding := rec(
 io_type := [ [ "iota" ], [ "K", "iota_source" ] ],
 with_given_object_position := "Source",
-universal_type := "Limit",
 filter_list := [ "category", "morphism" ],
 return_type := "morphism" ),
 


### PR DESCRIPTION
No need to bump versions of dependencies because this is backwards compatible.