### PR TITLE
include the derivations of Lift/Colift using Hom-Structure

### DIFF
--- a/ToolsForHigherHomologicalAlgebra/PackageInfo.g
+++ b/ToolsForHigherHomologicalAlgebra/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToolsForHigherHomologicalAlgebra",
 Subtitle := "Tools for the Higher Homological Algebra project",
-Version := "2022.12-01",
+Version := "2022.12-02",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHigherHomologicalAlgebra/gap/DerivedMethods.gi
+++ b/ToolsForHigherHomologicalAlgebra/gap/DerivedMethods.gi
@@ -1,0 +1,52 @@
+
+
+
+
+
+
+
+
+##
+AddDerivationToCAP( Lift,
+            [ [ IdentityMorphism, 1 ],
+              [ InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure, 1 ],
+              [ HomomorphismStructureOnMorphisms, 1 ],
+              [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism, 1 ],
+              [ Lift, 1, RangeCategoryOfHomomorphismStructure ] ],
+  function( cat, alpha, beta )
+    local range_cat, a, b;
+    
+    range_cat := RangeCategoryOfHomomorphismStructure( cat );
+    
+    a := InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat, alpha );
+    
+    b := HomomorphismStructureOnMorphisms( cat, IdentityMorphism( Source( alpha ) ), beta );
+    
+    return InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat, Source( alpha ), Source( beta ), Lift( range_cat, a, b ) );
+    
+end : CategoryGetters := rec( range_cat := RangeCategoryOfHomomorphismStructure ),
+      Description := "Derive Lift using the homomorphism structure and Lift in the range of the homomorphism structure" );
+
+##
+AddDerivationToCAP( Colift,
+            [
+              [ IdentityMorphism, 1 ],
+              [ InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure, 1 ],
+              [ HomomorphismStructureOnMorphisms, 1 ],
+              [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism, 1 ],
+              [ Lift, 1, RangeCategoryOfHomomorphismStructure ],
+            ],
+  function( cat, alpha, beta )
+    local range_cat, b, a;
+    
+    range_cat := RangeCategoryOfHomomorphismStructure( cat );
+    
+    b := InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( cat, beta );
+    
+    a := HomomorphismStructureOnMorphisms( cat, alpha, IdentityMorphism( Range( beta ) ) );
+    
+    return InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat, Range( alpha ), Range( beta ), Lift( range_cat, b, a ) );
+    
+end : CategoryGetters := rec( range_cat := RangeCategoryOfHomomorphismStructure ),
+      Description := "Derive Colift using the homomorphism structure and Lift in the range of the homomorphism structure" );
+

--- a/ToolsForHigherHomologicalAlgebra/read.g
+++ b/ToolsForHigherHomologicalAlgebra/read.g
@@ -8,6 +8,7 @@ ReadPackage( "ToolsForHigherHomologicalAlgebra", "gap/EnhancePackage.gi" );
 ReadPackage( "ToolsForHigherHomologicalAlgebra", "gap/CAP.gi");
 ReadPackage( "ToolsForHigherHomologicalAlgebra", "gap/LaTeX.gi" );
 ReadPackage( "ToolsForHigherHomologicalAlgebra", "gap/Functors.gi" );
+ReadPackage( "ToolsForHigherHomologicalAlgebra", "gap/DerivedMethods.gi" );
 
 if IsPackageMarkedForLoading( "JuliaInterface", ">= 0.2" ) then
     ReadPackage( "ToolsForHigherHomologicalAlgebra", "gap/JuliaInterface.gi" );


### PR DESCRIPTION
sothat the current ci-tests in FunctorCategories pass. These and other derivations should be moved to CAP