### PR TITLE
change the return type of WitnessIsomorphismFrom/OntoStandardConeObject

### DIFF
--- a/TriangulatedCategories/PackageInfo.g
+++ b/TriangulatedCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "TriangulatedCategories",
 Subtitle := "Framework for triangulated categories",
-Version := "2023.09-01",
+Version := "2024.09-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/TriangulatedCategories/gap/DerivedMethods.gi
+++ b/TriangulatedCategories/gap/DerivedMethods.gi
@@ -74,23 +74,37 @@ end : CategoryFilter := IsTriangulatedCategory );
 AddDerivationToCAP( IsExactTriangle,
                     "IsExactTriangle by WitnessIsomorphismIntoStandardConeObject",
                 [
-                  [ WitnessIsomorphismIntoStandardConeObject, 1 ],
+                  [ MorphismIntoStandardConeObject, 1 ],
+                  [ MorphismFromStandardConeObject, 1 ],
+                  [ MereExistenceOfSolutionOfLinearSystemInAbCategory, 1 ],
+                  [ IdentityMorphism, 2 ],
                 ],
   function( cat, alpha, iota, pi )
+    local iota_alpha, pi_alpha, left_coeffs, right_coeffs, right_side;
     
-    return WitnessIsomorphismIntoStandardConeObject( alpha, iota, pi ) <> fail;
+    iota_alpha := MorphismIntoStandardConeObject( alpha );
+    
+    pi_alpha := MorphismFromStandardConeObject( alpha );
+    
+    left_coeffs := [ [ iota ], [ IdentityMorphism( Range( iota )  ) ] ];
+    
+    right_coeffs := [ [ IdentityMorphism( Range( iota_alpha ) ) ], [ pi_alpha ] ];
+    
+    right_side := [ iota_alpha, pi ];
+    
+    return MereExistenceOfSolutionOfLinearSystemInAbCategory( cat, left_coeffs, right_coeffs, right_side );
     
 end : CategoryFilter := IsTriangulatedCategory );
 
 ##
-AddFinalDerivationBundle( "Adding witnesses for beeing exact by using SolveLinearSystemInAbCategoryOrFail",
+AddFinalDerivationBundle( "Adding witnesses for beeing exact by using SolveLinearSystemInAbCategory",
                 [
                   [ IsEqualForObjects, 1 ],
                   [ ShiftOfObject, 1 ],
                   [ MorphismIntoStandardConeObject, 1 ],
                   [ MorphismFromStandardConeObject, 1 ],
                   [ IdentityMorphism, 2 ],
-                  [ SolveLinearSystemInAbCategoryOrFail, 1 ],
+                  [ SolveLinearSystemInAbCategory, 1 ],
                   [ InverseForMorphisms, 1 ],
                 ],
                 [
@@ -105,7 +119,7 @@ AddFinalDerivationBundle( "Adding witnesses for beeing exact by using SolveLinea
     [ MorphismIntoStandardConeObject, 1 ],
     [ MorphismFromStandardConeObject, 1 ],
     [ IdentityMorphism, 2 ],
-    [ SolveLinearSystemInAbCategoryOrFail, 1 ],
+    [ SolveLinearSystemInAbCategory, 1 ],
   ],
   function( cat, alpha, iota, pi )
     local iota_alpha, pi_alpha, left_coeffs, right_coeffs, right_side, sol;
@@ -126,18 +140,10 @@ AddFinalDerivationBundle( "Adding witnesses for beeing exact by using SolveLinea
     
     right_side := [ iota_alpha, pi ];
     
-    sol := SolveLinearSystemInAbCategoryOrFail( left_coeffs, right_coeffs, right_side );
+    sol := SolveLinearSystemInAbCategory( left_coeffs, right_coeffs, right_side );
     
-    if sol = fail then
-      
-      return fail;
-      
-    else
-      
-      return sol[ 1 ];
-      
-    fi;
-  
+    return sol[ 1 ];
+    
   end
 ],
 [

--- a/TriangulatedCategories/gap/MethodRecord.gi
+++ b/TriangulatedCategories/gap/MethodRecord.gi
@@ -100,13 +100,13 @@ ShiftOfMorphismByInteger := rec(
 WitnessIsomorphismIntoStandardConeObject := rec(
   input_arguments_names := [ "cat", "alpha", "iota", "pi" ],
   filter_list := [ "category", "morphism", "morphism", "morphism" ],
-  return_type := "morphism_or_fail"
+  return_type := "morphism"
 ),
 
 WitnessIsomorphismFromStandardConeObject := rec(
   input_arguments_names := [ "cat", "alpha", "iota", "pi" ],
   filter_list := [ "category", "morphism", "morphism", "morphism" ],
-  return_type := "morphism_or_fail"
+  return_type := "morphism"
 ),
 
 IsExactTriangle := rec(


### PR DESCRIPTION
from "morphism_or_fail" to "morphism" and comply with that by using
  - `SolveLinearSystemInAbCategory`
  - `MereExistenceOfSolutionOfLinearSystemInAbCategory`

instead of `SolveLinearSystemInAbCategoryOrFail`

bump TriangulatedCategories to v2024.09-01